### PR TITLE
sos_names dictonary holding cf_names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@ Changelog
 
 Version 0.2.0
 
-* First first with the new API.
+* First release with the new API.
 * Added an Ocean Model Enhanced Cube Class `ecube`.
 
 Version 0.1.1

--- a/tardis/__init__.py
+++ b/tardis/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
 
-from .tardis import *
+from .tardis import OceanModelCube
+from . import coords
+from . import slices
+from . import utils
 
 __version__ = '0.2.0'

--- a/tardis/utils.py
+++ b/tardis/utils.py
@@ -11,10 +11,52 @@ iris.FUTURE.netcdf_promote = True
 iris.FUTURE.cell_datetime_objects = True
 
 
-__all__ = ['wrap_lon180',
+__all__ = ['cf_name_list',
+           'wrap_lon180',
            'wrap_lon360',
            'is_model',
            'is_water']
+
+salinity = ['sea_water_salinity',
+            'sea_surface_salinity',
+            'sea_water_absolute_salinity',
+            'sea_water_practical_salinity']
+
+temperature = ['sea_water_temperature',
+               'sea_surface_temperature',
+               'sea_water_potential_temperature',
+               'equivalent_potential_temperature',
+               'sea_water_conservative_temperature',
+               'pseudo_equivalent_potential_temperature']
+
+water_level = ['sea_surface_height',
+               'sea_surface_elevation',
+               'sea_surface_height_above_geoid',
+               'sea_surface_height_above_sea_level',
+               'water_surface_height_above_reference_datum',
+               'sea_surface_height_above_reference_ellipsoid']
+
+speed_direction = ['sea_water_speed', 'direction_of_sea_water_velocity']
+
+u = ['surface_eastward_sea_water_velocity',
+     'eastward_sea_water_velocity',
+     'sea_water_x_velocity',
+     'x_sea_water_velocity',
+     'eastward_transformed_eulerian_mean_velocity',
+     'eastward_sea_water_velocity_assuming_no_tide']
+
+v = ['northward_sea_water_velocity',
+     'surface_northward_sea_water_velocity',
+     'sea_water_y_velocity',
+     'y_sea_water_velocity',
+     'northward_transformed_eulerian_mean_velocity',
+     'northward_sea_water_velocity_assuming_no_tide']
+
+cf_name_list = dict(
+    {'salinity': salinity,
+     'sea_water_temperature': temperature,
+     'currents': dict(u=u, v=v, speed_direction=speed_direction),
+     'water_surface_height_above_reference_datum': water_level})
 
 
 def wrap_lon180(lon):


### PR DESCRIPTION
The user can easily pass a `cf_names` list via a single `sos_name` like:

``` python
from tardis.utils import cf_name_list
name_list = cf_name_list['sea_water_temperature']
name_list
```

``` python
['sea_water_temperature',
 'sea_surface_temperature',
 'sea_water_potential_temperature',
 'equivalent_potential_temperature',
 'sea_water_conservative_temperature',
 'pseudo_equivalent_potential_temperature']
```
