### PR TITLE
Do not rename coords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ before_install:
     - conda config --add channels ioos -f
     - travis_retry conda create --yes -n test $CONDA --file requirements.txt
     - source activate test
-    - travis_retry conda install --yes pytest
-    - conda info -a
+    - conda install --yes --file requirements-dev.txt
 
 script:
-    - python setup.py test
     - py.test --verbose --doctest-modules --ignore setup.py
+    - find . -type f -name "*.py" | xargs flake8 --max-line-length=100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+flake8
+pytest

--- a/tardis/coords.py
+++ b/tardis/coords.py
@@ -8,66 +8,8 @@ iris.FUTURE.netcdf_promote = True
 iris.FUTURE.cell_datetime_objects = True
 
 
-__all__ = ['x_coord',
-           'y_coord',
-           't_coord',
+__all__ = ['t_coord',
            'z_coord']
-
-
-def x_coord(cube):
-    """
-    Return the canonical x-coordinate and rename it to `longitude`.
-    If more than one x-coordinate is present it will try to return only
-    the one names `longitude`.
-
-    Examples
-    --------
-    >>> import iris
-    >>> url = ("http://omgsrv1.meas.ncsu.edu:8080/thredds/dodsC/fmrc/"
-    ...        "sabgom/SABGOM_Forecast_Model_Run_Collection_best.ncd")
-    >>> cube = iris.load_cube(url, 'sea_water_potential_temperature')
-    >>> x_coord(cube).name()
-    'longitude'
-
-    """
-    try:
-        # FIXME: This might wrongly rename some grids.
-        cube.coord(axis='X').rename('longitude')
-    except CoordinateNotFoundError:
-        # This will fail if there more than 1 x-coordinate
-        # and none are named `longitude`.
-        coord = cube.coord('longitude')
-    else:
-        coord = cube.coord('longitude')
-    return coord
-
-
-def y_coord(cube):
-    """
-    Return the canonical y-coordinate and rename it to `latitude`.
-    If more than one y-coordinate is present it will try to return only
-    the one names `latitude`.
-
-    Examples
-    --------
-    >>> import iris
-    >>> url = ("http://omgsrv1.meas.ncsu.edu:8080/thredds/dodsC/fmrc/"
-    ...        "sabgom/SABGOM_Forecast_Model_Run_Collection_best.ncd")
-    >>> cube = iris.load_cube(url, 'sea_water_potential_temperature')
-    >>> y_coord(cube).name()
-    'latitude'
-
-    """
-    try:
-        # FIXME: This might wrongly rename some grids.
-        cube.coord(axis='Y').rename('latitude')
-    except CoordinateNotFoundError:
-        # This will fail if there more than 1 y-coordinate
-        # and none are named `latitude`.
-        coord = cube.coord('latitude')
-    else:
-        coord = cube.coord('latitude')
-    return coord
 
 
 def t_coord(cube):

--- a/tardis/slices.py
+++ b/tardis/slices.py
@@ -5,7 +5,7 @@ import numpy as np
 import iris
 from iris import Constraint
 
-from .coords import x_coord, y_coord, z_coord, t_coord
+from .coords import z_coord, t_coord
 
 iris.FUTURE.netcdf_promote = True
 iris.FUTURE.cell_datetime_objects = True
@@ -91,8 +91,8 @@ def find_bbox(cube, bbox):
 
     """
     from oceans import wrap_lon180
-    lons = x_coord(cube).points
-    lats = y_coord(cube).points
+    lons = cube.coords(axis='X')[0].points
+    lats = cube.coords(axis='Y')[0].points
     lons = wrap_lon180(lons)
 
     inregion = np.logical_and(np.logical_and(lons > bbox[0],

--- a/tardis/tardis.py
+++ b/tardis/tardis.py
@@ -8,8 +8,11 @@ import pyugrid
 import pysgrid  # NOTE: Really?! How many custom exceptions to say ValueError?
 from pysgrid.custom_exceptions import SGridNonCompliantError
 
-from .coords import x_coord, y_coord
 from .utils import wrap_lon180, cf_name_list
+
+__all__ = ['load_phenomena',
+           'OceanModelCube',
+           'cf_name_list']
 
 
 def _get_grid(self):
@@ -110,8 +113,8 @@ class OceanModelCube(object):
         self.grid = _get_grid(self)
         self.grid_type = _get_grid_type(self)
         # NOTE: I always wrap longitude between -180, 180.
-        self.lon = wrap_lon180(x_coord(cube).points)
-        self.lat = y_coord(cube).points
+        self.lon = wrap_lon180(cube.coords(axis='X')[0].points)
+        self.lat = cube.coords(axis='Y')[0].points
 
     def __repr__(self):
         msg = "<OceanModelCube of {}. Grid type: {}>".format


### PR DESCRIPTION
Removed `x_coord()` and `y_coord()`.  Using the much simpler `cube.coords(axis='X/Y')[0]` to return the first coordinate.
